### PR TITLE
Switch nrows ncols

### DIFF
--- a/q100viz/grid.py
+++ b/q100viz/grid.py
@@ -74,8 +74,8 @@ class Grid:
                 for x, cell in enumerate(row):
                     cell.id, cell.rot = array[y * self.y_size + x]
 
-                    # object with ID 3 selects cells
-                    cell.selected = cell.id == 3
+                    # any non-white object selects cells
+                    cell.selected = cell.id != 0
 
                     # calculate relative rotation
                     # an inactive cell has a rotation value of -1

--- a/q100viz/grid.py
+++ b/q100viz/grid.py
@@ -17,7 +17,7 @@ class Grid:
         self.surface.calculate(viewport.transform_mat)
 
         # initialize two-dimensional array of grid cells
-        self.grid = [[GridCell() for x in range(x_size)] for y in range(y_size)]
+        self.grid = [[GridCell() for y in range(y_size)] for x in range(x_size)]
 
     def draw(self, surface):
         rects_transformed = [(cell, self.surface.transform([[x, y], [x, y + 1], [x + 1, y + 1], [x + 1, y]]))
@@ -25,7 +25,7 @@ class Grid:
 
         font = pygame.font.SysFont('Arial', 20)
 
-        # draw grid data
+        # draw grid data    
         for cell, rect_points in rects_transformed:
             self.surface.blit(
                 font.render(str(cell.id), True, (255, 255, 255)),
@@ -39,7 +39,7 @@ class Grid:
                 font.render(str(cell.rel_rot), True, (255, 127, 0)),
                 [rect_points[0][0] + 20, rect_points[0][1] + 20]
             )
-
+            
         # draw rectangle outlines
         for cell, rect_points in rects_transformed:
             stroke = 4 if cell.selected else 1

--- a/q100viz/grid.py
+++ b/q100viz/grid.py
@@ -3,6 +3,7 @@ import pygame
 
 import q100viz.keystone as keystone
 
+
 class Grid:
     def __init__(self, canvas_size, x_size, y_size, dst_points, viewport):
         self.x_size = x_size
@@ -17,7 +18,7 @@ class Grid:
         self.surface.calculate(viewport.transform_mat)
 
         # initialize two-dimensional array of grid cells
-        self.grid = [[GridCell() for y in range(y_size)] for x in range(x_size)]
+        self.grid = [[GridCell() for x in range(x_size)] for y in range(y_size)]
 
     def draw(self, surface):
         rects_transformed = [(cell, self.surface.transform([[x, y], [x, y + 1], [x + 1, y + 1], [x + 1, y]]))
@@ -25,7 +26,7 @@ class Grid:
 
         font = pygame.font.SysFont('Arial', 20)
 
-        # draw grid data    
+        # draw grid data
         for cell, rect_points in rects_transformed:
             self.surface.blit(
                 font.render(str(cell.id), True, (255, 255, 255)),
@@ -39,7 +40,7 @@ class Grid:
                 font.render(str(cell.rel_rot), True, (255, 127, 0)),
                 [rect_points[0][0] + 20, rect_points[0][1] + 20]
             )
-            
+
         # draw rectangle outlines
         for cell, rect_points in rects_transformed:
             stroke = 4 if cell.selected else 1
@@ -72,7 +73,7 @@ class Grid:
         try:
             for y, row in enumerate(self.grid):
                 for x, cell in enumerate(row):
-                    cell.id, cell.rot = array[y * self.y_size + x]
+                    cell.id, cell.rot = array[y * self.x_size + x]
 
                     # any non-white object selects cells
                     cell.selected = cell.id != 0

--- a/run_q100viz.py
+++ b/run_q100viz.py
@@ -70,7 +70,7 @@ basemap.warp()
 grid_settings = json.load(open(config['CSPY_SETTINGS_FILE']))['cityscopy']
 nrows = grid_settings['nrows']
 ncols = grid_settings['ncols']
-grid_1 = session.grid_1 = grid.Grid(canvas_size, nrows, ncols, [[50, 0], [50, 81], [100, 81], [100, 0]], viewport)
+grid_1 = session.grid_1 = grid.Grid(canvas_size, ncols, nrows, [[50, 0], [50, 81], [100, 81], [100, 0]], viewport)
 grid_2 = session.grid_2 = grid.Grid(canvas_size, 22, 22, [[0, 0], [0, 100], [50, 100], [50, 0]], viewport)
 
 show_basemap = False

--- a/run_q100viz.py
+++ b/run_q100viz.py
@@ -70,8 +70,8 @@ basemap.warp()
 grid_settings = json.load(open(config['CSPY_SETTINGS_FILE']))['cityscopy']
 nrows = grid_settings['nrows']
 ncols = grid_settings['ncols']
-grid_1 = session.grid_1 = grid.Grid(canvas_size, 22, 22, [[0, 0], [0, 100], [50, 100], [50, 0]], viewport)
-grid_2 = session.grid_2 = grid.Grid(canvas_size, 22, 22, [[50, 0], [50, 100], [100, 100], [100, 0]], viewport)
+grid_1 = session.grid_1 = grid.Grid(canvas_size, ncols, nrows, [[50, 0], [50, 81], [100, 81], [100, 0]], viewport)
+grid_2 = session.grid_2 = grid.Grid(canvas_size, 22, 22, [[0, 0], [0, 100], [50, 100], [50, 0]], viewport)
 
 show_basemap = False
 show_grid = False

--- a/run_q100viz.py
+++ b/run_q100viz.py
@@ -70,7 +70,7 @@ basemap.warp()
 grid_settings = json.load(open(config['CSPY_SETTINGS_FILE']))['cityscopy']
 nrows = grid_settings['nrows']
 ncols = grid_settings['ncols']
-grid_1 = session.grid_1 = grid.Grid(canvas_size, ncols, nrows, [[50, 0], [50, 81], [100, 81], [100, 0]], viewport)
+grid_1 = session.grid_1 = grid.Grid(canvas_size, nrows, ncols, [[50, 0], [50, 81], [100, 81], [100, 0]], viewport)
 grid_2 = session.grid_2 = grid.Grid(canvas_size, 22, 22, [[0, 0], [0, 100], [50, 100], [50, 0]], viewport)
 
 show_basemap = False


### PR DESCRIPTION
Der Code erzeugt bei mir in kombination mit dem [entsprechenden branch in cspy](https://github.com/dunland/cspy/tree/switch_nrows_ncols)  zusammenpassende Ergebnisse. Allerdings bin ich mir unsicher, ob dadurch die Logik der Grid-Erzeugung noch bewahrt wird, oder ob ich sie durcheinander bringe..

--> run_q100viz.py Zeile 73: `grid_1 = session.grid_1 = grid.Grid(canvas_size, nrows, ncols, [[50, 0], [50, 81], [100, 81], [100, 0]], viewport)`


pls review!

Vergleichsansicht:
https://github.com/dunland/q100_viz/commit/91bba7063af22ba9b50c8cb3acc2521bed0e9b5a?branch=91bba7063af22ba9b50c8cb3acc2521bed0e9b5a&diff=split
